### PR TITLE
fixed config.json syntax

### DIFF
--- a/pico/config.json
+++ b/pico/config.json
@@ -25,6 +25,6 @@
             -104.9848
         ],
         "masl": 1609.0,
-        "antenna": = null
+        "antenna": null
     }
 }


### PR DESCRIPTION
config.json syntax was broken

There are a few other code issues that prevent this running under v1.23.0, notably rshell using `/pyboard` instead of `/flash` for on-board file system